### PR TITLE
Correct capitalization of filename in includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=See more on http://M5Stack.com
 category=Device Control
 url=https://platformio.org/lib/show/4529/M5Stack-Avatar
 architectures=esp32
-includes=avatar.h
+includes=Avatar.h


### PR DESCRIPTION
## Description

Incorrect filename capitalization in the `includes` field of library.properties results in compilation error of sketch after `#include` directive is inserted into sketch using the Arduino IDE's **Sketch > Include library > M5Stack_Avatar**.

## Type of change
- [x] Bug fix