### PR TITLE
fix platformio link error

### DIFF
--- a/library.json
+++ b/library.json
@@ -16,8 +16,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "name": "M5Stack",
-    "version": ">=0.2.0"
   },
   "version": "0.7.3",
   "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,3 @@ category=Device Control
 url=https://platformio.org/lib/show/4529/M5Stack-Avatar
 architectures=esp32
 includes=Avatar.h
-depends=M5Stack

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -122,19 +122,19 @@ void Avatar::start() {
                           NULL);        /* Task handle. */
   xTaskCreate(saccade,      /* Function to implement the task */
                           "saccade",    /* Name of the task */
-                          512,         /* Stack size in words */
+                          1024,         /* Stack size in words */
                           ctx,          /* Task input parameter */
                           2,            /* Priority of the task */
                           NULL);        /* Task handle. */
   xTaskCreate(updateBreath, /* Function to implement the task */
                           "breath",     /* Name of the task */
-                          512,         /* Stack size in words */
+                          1024,         /* Stack size in words */
                           ctx,          /* Task input parameter */
                           2,            /* Priority of the task */
                           NULL);        /* Task handle. */
   xTaskCreate(blink,        /* Function to implement the task */
                           "blink",      /* Name of the task */
-                          512,         /* Stack size in words */
+                          1024,         /* Stack size in words */
                           ctx,          /* Task input parameter */
                           2,            /* Priority of the task */
                           NULL);        /* Task handle. */


### PR DESCRIPTION
## Description

Fixed a link error that occurred when building for M5Stack Core2 in VSCode+Platformio environment because M5Stack.h was loaded due to dependency settings.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
