### PR TITLE
add setSpeechFont

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -147,7 +147,7 @@ void Avatar::draw() {
   DrawContext *ctx = new DrawContext(this->expression, this->breath,
                                      &this->palette, g, this->eyeOpenRatio,
                                      this->mouthOpenRatio, this->speechText,
-                                     this->rotation, this->scale, this->colorDepth);
+                                     this->rotation, this->scale, this->colorDepth, this->speechFont);
   face->draw(ctx);
   delete ctx;
 }
@@ -196,6 +196,10 @@ void Avatar::getGaze(float *vertical, float *horizontal) {
 
 void Avatar::setSpeechText(const char *speechText) {
   this->speechText = speechText;
+}
+
+void Avatar::setSpeechFont(const lgfx::IFont *speechFont) {
+  this->speechFont = speechFont;
 }
 
 }  // namespace m5avatar

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -6,6 +6,7 @@
 #define AVATAR_H_
 #include "ColorPalette.h"
 #include "Face.h"
+#include <M5GFX.h>
 
 namespace m5avatar {
 class Avatar {
@@ -23,6 +24,7 @@ class Avatar {
   ColorPalette palette;
   const char *speechText;
   int colorDepth;
+  const lgfx::IFont *speechFont;
 
  public:
   Avatar();
@@ -44,6 +46,7 @@ class Avatar {
   void setEyeOpenRatio(float ratio);
   void setMouthOpenRatio(float ratio);
   void setSpeechText(const char *speechText);
+  void setSpeechFont(const lgfx::IFont *speechFont);
   void setRotation(float radian);
   void setPosition(int top, int left);
   void setScale(float scale);

--- a/src/Balloon.h
+++ b/src/Balloon.h
@@ -28,6 +28,7 @@ class Balloon final : public Drawable {
   void draw(M5Canvas *spi, BoundingRect rect,
             DrawContext *drawContext) override {
     const char *text = drawContext->getspeechText();
+    const lgfx::IFont *font = drawContext->getSpeechFont();
     if (strlen(text) == 0) {
       return;
     }
@@ -36,6 +37,7 @@ class Balloon final : public Drawable {
     spi->setTextSize(TEXT_SIZE);
     spi->setTextColor(primaryColor, backgroundColor);
     spi->setTextDatum(MC_DATUM);
+    M5.Lcd.setFont(font);
     int textWidth = M5.Lcd.textWidth(text);
     int textHeight = TEXT_HEIGHT * TEXT_SIZE;
     spi->fillEllipse(cx, cy, _max(textWidth, MIN_WIDTH) + 2, textHeight * 2 + 2,
@@ -46,8 +48,7 @@ class Balloon final : public Drawable {
                      backgroundColor);
     spi->fillTriangle(cx - 60, cy - 40, cx - 10, cy - 10, cx - 40, cy - 10,
                       backgroundColor);
-    spi->drawString(text, cx, cy,
-                    2);  // Continue printing from new x position
+    spi->drawString(text, cx, cy, font);//&fonts::lgfxJapanGothic_16);  // Continue printing from new x position
   }
 };
 

--- a/src/DrawContext.cpp
+++ b/src/DrawContext.cpp
@@ -9,13 +9,13 @@ namespace m5avatar {
 DrawContext::DrawContext(Expression expression, float breath,
                          ColorPalette* const palette, Gaze gaze,
                          float eyeOpenRatio, float mouthOpenRatio,
-                         const char* speechText)
-    : DrawContext(expression, breath, palette, gaze, eyeOpenRatio, mouthOpenRatio, speechText, 0, 1, 1){};
+                         const char* speechText, const lgfx::IFont* speechFont)
+    : DrawContext(expression, breath, palette, gaze, eyeOpenRatio, mouthOpenRatio, speechText, 0, 1, 1, speechFont){};
 
 DrawContext::DrawContext(Expression expression, float breath,
                          ColorPalette* const palette, Gaze gaze,
                          float eyeOpenRatio, float mouthOpenRatio,
-                         const char* speechText, float rotation, float scale, int colorDepth) 
+                         const char* speechText, float rotation, float scale, int colorDepth, const lgfx::IFont* speechFont) 
     : expression{expression},
       breath{breath},
       eyeOpenRatio{eyeOpenRatio},
@@ -25,7 +25,8 @@ DrawContext::DrawContext(Expression expression, float breath,
       speechText{speechText},
       rotation{rotation},
       scale{scale},
-      colorDepth{colorDepth}{}
+      colorDepth{colorDepth},
+      speechFont{speechFont}{}
 
 Expression DrawContext::getExpression() const { return expression; }
 
@@ -46,5 +47,7 @@ Gaze DrawContext::getGaze() const { return gaze; }
 ColorPalette* const DrawContext::getColorPalette() const { return palette; }
 
 int DrawContext::getColorDepth() const { return colorDepth; }
+
+const lgfx::IFont* DrawContext::getSpeechFont() const { return speechFont; }
 
 }  // namespace m5avatar

--- a/src/DrawContext.h
+++ b/src/DrawContext.h
@@ -7,6 +7,7 @@
 
 #define ERACER_COLOR 0x0000
 
+#include "M5GFX.h"
 #include "ColorPalette.h"
 #include "Expression.h"
 #include "Gaze.h"
@@ -24,15 +25,16 @@ class DrawContext {
   float rotation = 0.0;
   float scale = 1.0;
   int colorDepth = 1;
+  const lgfx::IFont* speechFont = nullptr; // = &fonts::lgfxJapanGothicP_16; //  = &fonts::efontCN_10;
 
  public:
   DrawContext() = delete;
   DrawContext(Expression expression, float breath, ColorPalette* const palette,
               Gaze gaze, float eyeOpenRatio, float mouthOpenRatio,
-              const char* speechText);
+              const char* speechText, const lgfx::IFont* speechFont);
   DrawContext(Expression expression, float breath, ColorPalette* const palette,
               Gaze gaze, float eyeOpenRatio, float mouthOpenRatio,
-              const char* speechText, float rotation, float scale, int colorDepth);
+              const char* speechText, float rotation, float scale, int colorDepth, const lgfx::IFont* speechFont);
   ~DrawContext() = default;
   DrawContext(const DrawContext& other) = delete;
   DrawContext& operator=(const DrawContext& other) = delete;
@@ -46,6 +48,7 @@ class DrawContext {
   ColorPalette* const getColorPalette() const;
   const char* getspeechText() const;
   int getColorDepth() const;
+  const lgfx::IFont* getSpeechFont() const; 
 };
 }  // namespace m5avatar
 


### PR DESCRIPTION
Allows you to set the font to be used in Balloon, specifying the name of the M5Unified font.

- Available Font List

https://docs.m5stack.com/en/api/m5gfx/m5gfx_appendix#font-list

## Type of change

- [x] Feature Enhancement
