### PR TITLE
APP_CPU_NUM fallback for single-core MCUs

### DIFF
--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -8,6 +8,10 @@
 #include "Face.h"
 #include <M5GFX.h>
 
+#ifndef APP_CPU_NUM
+#define APP_CPU_NUM PRO_CPU_NUM
+#endif
+
 namespace m5avatar {
 class Avatar {
  private:


### PR DESCRIPTION
## Description

The following error occurred when trying to compile for a module using ESP32C3.
Similar errors are expected to occur with single-core MCUs.

```text
.pio/libdeps/wired/M5Stack-Avatar/src/Avatar.cpp: In member function 'void m5avatar::Avatar::addTask(TaskFunction_t, const char*)':
.pio/libdeps/wired/M5Stack-Avatar/src/Avatar.cpp:105:27: error: 'APP_CPU_NUM' was not declared in this scope
                           APP_CPU_NUM);
                           ^~~~~~~~~~~
.pio/libdeps/wired/M5Stack-Avatar/src/Avatar.cpp:105:27: note: suggested alternative: 'PRO_CPU_NUM'
                           APP_CPU_NUM);
                           ^~~~~~~~~~~
                           PRO_CPU_NUM
.pio/libdeps/wired/M5Stack-Avatar/src/Avatar.cpp:144:27: error: 'APP_CPU_NUM' was not declared in this scope
                           APP_CPU_NUM);
                           ^~~~~~~~~~~
.pio/libdeps/wired/M5Stack-Avatar/src/Avatar.cpp:144:27: note: suggested alternative: 'PRO_CPU_NUM'                           APP_CPU_NUM);
                           ^~~~~~~~~~~
                           PRO_CPU_NUM
*** [.pio\build\wired\lib5d3\M5Stack-Avatar\Avatar.cpp.o] Error 1
```

Preparing a fallback from APP_CPU_NUM to PRO_CPU_NUM solves this problem.

## Type of change

- [x] Bug fix
- [x] Feature Enhancement
