### PR TITLE
Add Graph to Doxygen Diagram

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -16,11 +16,6 @@ jobs:
         run: |
           curl -OL https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/main/doxygen-awesome.css
       - uses: mattnotmitt/doxygen-action@v1.9.5
-      - name: copy file
-        uses: canastro/copy-file-action@master
-        with:
-          source: "docs"
-          target: "html"
       - name: Deploy pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -16,6 +16,8 @@ jobs:
         run: |
           curl -OL https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/main/doxygen-awesome.css
       - uses: mattnotmitt/doxygen-action@v1.9.5
+      - name: copy image
+        run: cp -r docs html
       - name: Deploy pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,9 +1,10 @@
 name: A job to build doxgen document and deploy it on github-pages
 on:
   push:
-    branches: [main, master, doxygen]
-  pull_request:
-    branches: [main, master]
+    branches:
+      - main
+      - master
+      - 'doxygen*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -16,8 +16,11 @@ jobs:
         run: |
           curl -OL https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/main/doxygen-awesome.css
       - uses: mattnotmitt/doxygen-action@v1.9.5
-      - name: copy image
-        run: cp -r docs html
+      - name: copy file
+        uses: canastro/copy-file-action@master
+        with:
+          source: "docs"
+          target: "html"
       - name: Deploy pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/Doxyfile
+++ b/Doxyfile
@@ -874,7 +874,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1034,7 +1034,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/Doxyfile
+++ b/Doxyfile
@@ -874,7 +874,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = README.md
+INPUT                  = README.md src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -2278,7 +2278,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of
@@ -2347,7 +2347,7 @@ GROUP_GRAPHS           = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-UML_LOOK               = NO
+UML_LOOK               = YES
 
 # If the UML_LOOK tag is enabled, the fields and methods are shown inside the
 # class node. If there are many fields or methods and many nodes the graph may
@@ -2470,7 +2470,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.
@@ -2482,7 +2482,7 @@ DOT_IMAGE_FORMAT       = png
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INTERACTIVE_SVG        = NO
+INTERACTIVE_SVG        = YES
 
 # The DOT_PATH tag can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.


### PR DESCRIPTION
## Description
Update workflow of doxygen

- Add graphs to doxygen pages such as [ClassHierarchy](https://botamochi6277.github.io/m5stack-avatar/inherits.html)
- Add readme.md to the main page of doxygen. For example, [index.html](https://botamochi6277.github.io/m5stack-avatar/index.html) 
- Remove triggers of  "on pull requests" (This action fails due to permission )

## Type of change

- [x] Feature Enhancement

